### PR TITLE
Add additional OAEP support for OpenSSL module

### DIFF
--- a/lib/openssl/oaep.rb
+++ b/lib/openssl/oaep.rb
@@ -1,7 +1,107 @@
-require "openssl/oaep/version"
+require 'openssl/oaep/version'
+require 'openssl'
+require 'securerandom'
 
-module Openssl
-  module Oaep
-    # Your code goes here...
+module OpenSSL
+  # Extends the OpenSSL library.
+
+  module PKey
+    class RSA
+      def public_encrypt_oaep(str, label = '', md = nil, mgf1md = nil)
+        padded = PKCS1.add_oaep_mgf1(str, n.num_bytes, label, md, mgf1md)
+        public_encrypt(padded, OpenSSL::PKey::RSA::NO_PADDING)
+      end
+
+      def private_decrypt_oaep(str, label = '', md = nil, mgf1md = nil)
+        padded = private_decrypt(str, OpenSSL::PKey::RSA::NO_PADDING)
+        PKCS1.check_oaep_mgf1(padded, label, md, mgf1md)
+      end
+    end
+  end
+
+  module PKCS1
+    def add_oaep_mgf1(str, len, label = '', md = nil, mgf1md = nil)
+      md ||= OpenSSL::Digest::SHA1
+      mgf1md ||= md
+
+      mdlen = md.new.digest_length
+      z_len = len - str.bytesize - 2 * mdlen - 2
+      if z_len < 0
+        raise OpenSSL::PKey::RSAError, 'data too large for key size'
+      end
+      if len < 2 * mdlen + 1
+        raise OpenSSL::PKey::RSAError, 'key size too small'
+      end
+
+      l_hash = md.digest(label)
+      db = l_hash + ([0] * z_len + [1]).pack('C*') + [str].pack('a*')
+      seed = SecureRandom.random_bytes(mdlen)
+
+      masked_db = mgf1_xor(db, seed, mgf1md)
+      masked_seed = mgf1_xor(seed, masked_db, mgf1md)
+
+      [0, masked_seed, masked_db].pack('Ca*a*')
+    end
+
+    module_function :add_oaep_mgf1
+
+    def check_oaep_mgf1(str, label = '', md = nil, mgf1md = nil)
+      md ||= OpenSSL::Digest::SHA1
+      mgf1md ||= md
+
+      mdlen = md.new.digest_length
+      em = str.bytes
+      if em.size < 2 * mdlen + 2
+        raise OpenSSL::PKey::RSAError
+      end
+
+      # Keep constant calculation even if the text is invaid in order to avoid attacks.
+      good = (em[0] == 0 ? 1 : 0)
+      masked_seed = em[1...1+mdlen].pack('C*')
+      masked_db = em[1+mdlen...em.size].pack('C*')
+
+      seed = mgf1_xor(masked_seed, masked_db, mgf1md)
+      db = mgf1_xor(masked_db, seed, mgf1md)
+      db_bytes = db.bytes
+
+      l_hash = md.digest(label)
+      good &= (l_hash == db_bytes[0...mdlen].pack('C*') ? 1 : 0)
+
+      one_index = 0
+      found_one_byte = 0
+      (mdlen...db_bytes.size).each do |i|
+        equals1 = db_bytes[i] == 1 ? 1 : 0
+        equals0 = db_bytes[i] == 0 ? 1 : 0
+        one_index = ~found_one_byte & equals1 == 1 ? i : one_index
+        found_one_byte |= equals1
+        good &= ((found_one_byte | equals0) == 1 ? 1 : 0)
+      end
+
+      good &= (found_one_byte == 1 ? 1 : 0)
+
+      if good != 1
+        raise OpenSSL::PKey::RSAError
+      end
+
+      db_bytes[one_index+1...db_bytes.size].pack('C*')
+    end
+
+    module_function :check_oaep_mgf1
+
+    def mgf1_xor(out, seed, md)
+      counter = 0
+      out_bytes = out.bytes
+      mask_bytes = []
+      while mask_bytes.size < out_bytes.size
+        mask_bytes += md.digest([seed, counter].pack('a*N')).bytes
+        counter += 1
+      end
+      out_bytes.size.times do |i|
+        out_bytes[i] ^= mask_bytes[i]
+      end
+      out_bytes.pack('C*')
+    end
+
+    module_function :mgf1_xor
   end
 end

--- a/spec/openssl/oaep_spec.rb
+++ b/spec/openssl/oaep_spec.rb
@@ -1,11 +1,122 @@
-require "spec_helper"
+require 'spec_helper'
 
 RSpec.describe Openssl::Oaep do
-  it "has a version number" do
+  it 'has a version number' do
     expect(Openssl::Oaep::VERSION).not_to be nil
   end
 
-  it "does something useful" do
-    expect(false).to eq(true)
+  describe 'RSA' do
+    let(:key) { OpenSSL::PKey::RSA.generate(1024) }
+    let(:plan_text) { 'abcdefghij' }
+    let(:label) { '' }
+    let(:md) { nil }
+    let(:mgf1md) { nil }
+    let(:label_d) { label }
+    let(:md_d) { md }
+    let(:mgf1md_d) { mgf1md }
+
+    shared_examples 'success' do
+      it 'results in the same text' do
+        encrypted = key.public_encrypt_oaep(plan_text, label, md, mgf1md)
+        decrypted = key.private_decrypt_oaep(encrypted, label, md, mgf1md)
+        expect(decrypted).to eq(plan_text)
+      end
+    end
+
+    shared_examples 'fail on encryption' do
+      it 'raises error on encrypt' do
+        expect { key.public_encrypt_oaep(plan_text, label, md, mgf1md) }.to raise_error(OpenSSL::PKey::RSAError)
+      end
+    end
+
+    shared_examples 'fail on decryption' do
+      it 'raises error on decrypt' do
+        encrypted = key.public_encrypt_oaep(plan_text, label, md, mgf1md)
+        expect { key.private_decrypt_oaep(encrypted, label_d, md_d, mgf1md_d) }.to raise_error(OpenSSL::PKey::RSAError)
+      end
+    end
+
+    context 'with default params' do
+      it_behaves_like 'success'
+    end
+
+    context 'with various params' do
+      let(:label) { 'label' }
+      let(:md) { OpenSSL::Digest::SHA256 }
+      let(:mgf1md) { OpenSSL::Digest::SHA512 }
+      it_behaves_like 'success'
+    end
+
+    describe 'source text length limit' do
+      context 'with max plan text length' do
+        let(:plan_text) { 'a' * 86 }
+        it_behaves_like 'success'
+      end
+
+      context 'with longer plan text' do
+        let(:plan_text) { 'a' * 87 }
+        it_behaves_like 'fail on encryption'
+      end
+    end
+
+    describe 'with inconsistent params' do
+      context 'with different labels' do
+        let(:label) { 'label' }
+        let(:label_d) { 'label2' }
+        it_behaves_like 'fail on decryption'
+      end
+
+      context 'with different md' do
+        let(:md) { OpenSSL::Digest::SHA256 }
+        let(:md_d) { OpenSSL::Digest::SHA1 }
+        it_behaves_like 'fail on decryption'
+      end
+
+      context 'with different mgf1md' do
+        let(:mgf1md) { OpenSSL::Digest::SHA256 }
+        let(:mgf1md_d) { OpenSSL::Digest::SHA1 }
+        it_behaves_like 'fail on decryption'
+      end
+    end
+  end
+
+  OAEP_DATA = [
+    {
+      msg: 'abcdefghij',
+      len: 256,
+      label:  '',
+      md: nil,
+      mgf1md: nil,
+      rand: "\x85\x93\xEA\x9C\xC1\xC1@\xD6Z\x8F#6\xC6\xA3\xAD\x8C,!\xB7\xDE".b,
+      em: "\x00M\x91\x7F\xC1e(hf\x99e\x1E\xFF2\xE5\x16\xB9S\x10u\xF7Q\v8\xD1\xD1x\xD1W\xF2\xE4\x91C\xE0\x80\xD6\xBA\xD2/\x14\xB9\x01&\xC4\x95\xF1\x16\xD3\xE9'R[gsq\xD2\xE4\xA9+\xF6o\x9E\x81\x14J\xE3\x94E\xA5\xB2\xDA<\xDC\xFB2\x7F\x91\xD1\xB6\xBF\xCC\xB1mn\x96gn\x97\xC0\xFA\xDA\x04\r\x8B`i\xDE\xE7\xE4$\xFC\x92\x9Dm\xCDwT\xDE\xD3\xF3\xFD\xF2)\xB0\xBC`\xA6\x8A\x0Ed\x8B:\aK\x1A\xC7C\xB7\xBCP\xE4b\xE7#\x1F5\x92\xAA\x97\xE2\x82\xC9\xC5~\x147\x89\xF4\x02WV\t\x8BM\xA55\\]\x87`\x8D\x11b5\x19\xB8]5H\xB47\xBE\f\x85w\xA1\xF0-Z/WbG[z\xD5\x9DV\xDC'\x8F!L\xE4\xE6\xC9\xFB\xACQ*\b\xDA\x917\xD7y\xC5b\xC6\xD8!\x1A.\r\xCE\a\xE3\xC0H\xA1;\xB4\xA0\xBE\xB7\x8E}J\x1D\xC5P:V6Y\xA9R[\x88s\xCFy\x02\xD1_\x06\x97\xDE\xC6\x9E\xD2\x81)\xD6X,".b,
+    },
+    {
+      msg: 'xyz',
+      len: 256,
+      label:  'label',
+      md: OpenSSL::Digest::SHA256,
+      mgf1md: nil,
+      rand: "\xDB\x14\xF5X\x14Q\x80\x89\x81\xBC\xC1\x8D\x0F\x8D\xF2\xD2\xF7\x1E\x16^\xA4\a)\xFC\x90w!\xFE\xE2\x19\x89\x93".b,
+      em: "\x00\xE5DPm\x82\x14\xB9oP\xE1\xF4\xEA\xB6=\x14\x8B\xB9\xEA\xB0\xBB\xA3\x85\xB9\xA2\x13H\xC3r\xEE\xDE\xAF\x16\x81&\x99B\x94\x9C\xEC\xBE\x84\x14q\xA2\x80\xD0\xB5\xE7>\xA4\xAE\xB6h\xA2\x95\x06=\x11\"b\x1F\x91\x0F\x82\xDF\xEAas\xCFj\xA8\xA0\xAC9\x9C\xE1\xEFt\xAF\xDF\x0E\xBA62`\xF3\r\xE6\xCA\x96\x19!\x17\xD2\x12\\\xFF\xFA9K\xCD\xA01\xC9d\xF5\x80S\xE3\x14\xAC\xFA%\xCBY\xCBG$xQ\xD8\xE41^\xBF\xED\xB5(\xFE\x9F\xDEa*\xDC!\\\xFC\xEF$M\x9C\xBEQ\xB6\xE7#\x94`r-\xA4#\xBCx\xFB\xE3\xA2o%\x8F\x83.$i;\x97g\xB6\xB0\xFFH\xF5l4\x8E\xE1\xEA\x03\xEE\x8DF\x89\xFA\x8B\x9C@\xF1\x8Dc\xF4i\x1C\x816\\\xBEkk\x9At\x8AB\x1FF\xEBa\xEA\x80\xD2\xF9@e\xD3\xBEm\xD4\xFA\xBA\xD2.\xCBT55\xBC\x03\xD5\xA3\xFF\x81RkW$\x17\x9C\x1DrX&W\xBF\x8D\xE3\x99\x9Cw\xCC\x04m\tD\x8C\xCF\f".b,
+    },
+  ]
+
+  describe 'PKCS1.add_oaep_mgf1' do
+    it 'adds padding correctly' do
+      OAEP_DATA.each do |msg:, len:, label:, md:, mgf1md:, rand:, em:|
+        expect(SecureRandom).to receive(:random_bytes) { rand }
+        encrypted = OpenSSL::PKCS1.add_oaep_mgf1(msg, len, label, md, mgf1md)
+        expect(encrypted).to eq(em)
+      end
+    end
+  end
+
+  describe 'PKCS1.check_oaep_mgf1' do
+    it 'checks padding correctly' do
+      OAEP_DATA.each do |msg:, len:, label:, md:, mgf1md:, rand:, em:|
+        decrypted = OpenSSL::PKCS1.check_oaep_mgf1(em, label, md, mgf1md)
+        expect(decrypted).to eq(msg)
+      end
+    end
   end
 end


### PR DESCRIPTION
Extend the `OpenSSL` module.
`OpenSSL:: PKCS1` supports OAEP padding as same as `RSA_padding_add_PKCS1_OAEP_mgf1` and `RSA_padding_check_PKCS1_OAEP_mgf1 ` in the OpenSSL library.
`OpenSSL::PKey::RSA#public_encrypt_oaep` and`OpenSSL::PKey::RSA#private_decrypt_oaep` provides quick utilities for common use cases.